### PR TITLE
Update the examples so they can run on the latest beta (0.2.006)

### DIFF
--- a/examples/blend/module.jai
+++ b/examples/blend/module.jai
@@ -13,7 +13,6 @@
 
 NUM_BLEND_FACTORS :: 15;
 
-default_context: Context;
 state: struct {
     pass_action:    sg_pass_action;
     bind:           sg_bindings;
@@ -25,10 +24,10 @@ state: struct {
 }
 
 init :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
     sg_setup(*(sg_desc.{
         pipeline_pool_size = NUM_BLEND_FACTORS * NUM_BLEND_FACTORS + 1,
-        environment = xx sglue_environment(),
+        environment = xx,force sglue_environment(),
         logger = .{ func = slog_func },
     }));
 
@@ -80,7 +79,7 @@ init :: () #c_call {
 }
 
 frame :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
     t := cast(float) (sapp_frame_duration() * 60.0);
     state.r += 0.6 * t;
     state.bg_fs_params.tick += 1.0 * t;
@@ -91,7 +90,7 @@ frame :: () #c_call {
     view_proj := multiply_mat4(proj, view);
 
     // start rendering
-    sg_begin_pass(*(sg_pass.{ action = state.pass_action, swapchain = xx sglue_swapchain() }));
+    sg_begin_pass(*(sg_pass.{ action = state.pass_action, swapchain = xx,force sglue_swapchain() }));
 
     // draw a background quad
     sg_apply_pipeline(state.bg_pip);

--- a/examples/clear/module.jai
+++ b/examples/clear/module.jai
@@ -9,14 +9,13 @@
 #import,dir "../../sokol/app"(USE_GL=USE_GL);
 #import,dir "../../sokol/glue"(USE_GL=USE_GL);
 
-default_context: Context;
 pass_action: sg_pass_action;
 
 init :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
 
     sg_setup(*(sg_desc.{
-        environment = xx sglue_environment(),
+        environment = xx,force sglue_environment(),
         logger = .{ func = slog_func },
     }));
     pass_action.colors[0] = .{ load_action = .CLEAR, clear_value = .{ 1.0, 0.0, 0.0, 1.0 } };
@@ -37,7 +36,7 @@ init :: () #c_call {
 frame :: () #c_call {
     g := pass_action.colors[0].clear_value.g + 0.01;
     pass_action.colors[0].clear_value.g = ifx(g > 1.0) then 0.0 else g;
-    sg_begin_pass(*(sg_pass.{ action = pass_action, swapchain = xx sglue_swapchain() }));
+    sg_begin_pass(*(sg_pass.{ action = pass_action, swapchain = xx,force sglue_swapchain() }));
     sg_end_pass();
     sg_commit();
 }

--- a/examples/debugtext-print/module.jai
+++ b/examples/debugtext-print/module.jai
@@ -16,7 +16,6 @@ Color :: struct {
     r, g, b: u8;
 }
 
-default_context: Context;
 state: struct {
     pass_action: sg_pass_action;
     palette: [3]Color;
@@ -36,7 +35,7 @@ state: struct {
 
 init :: () #c_call {
     sg_setup(*(sg_desc.{
-        environment = xx sglue_environment(),
+        environment = xx,force sglue_environment(),
         logger = .{ func = slog_func },
     }));
 
@@ -49,7 +48,7 @@ init :: () #c_call {
 }
 
 frame :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
 
     frame_count := cast(u32) sapp_frame_count();
     frame_time := sapp_frame_duration() * 1000.0;
@@ -58,7 +57,7 @@ frame :: () #c_call {
     sdtx_origin(3.0, 3.0);
     for i : 0 .. NUM_FONTS-1 {
         color := state.palette[i];
-        sdtx_font(xx i);
+        sdtx_font(cast(s32) i);
         sdtx_color3b(color.r, color.g, color.b);
         sdtx_printf("Hello '%'!\n", ifx((frame_count & (1<<7)) == 0) then "Welt" else "World");
         sdtx_printf("\tFrame Time:\t\t%.3f\n", frame_time);
@@ -68,7 +67,7 @@ frame :: () #c_call {
         sdtx_move_y(2);
     }
 
-    sg_begin_pass(*(sg_pass.{ action = state.pass_action, swapchain = xx sglue_swapchain() }));
+    sg_begin_pass(*(sg_pass.{ action = state.pass_action, swapchain = xx,force sglue_swapchain() }));
     sdtx_draw();
     sg_end_pass();
     sg_commit();

--- a/examples/fontstash-sapp/module.jai
+++ b/examples/fontstash-sapp/module.jai
@@ -12,7 +12,6 @@
 #import,dir "../../sokol/gl"(USE_GL=USE_GL);
 #import,dir "../../sokol/fontstash"(USE_GL=USE_GL);
 
-default_context: Context;
 state: struct {
     fons: *FONScontext;
     dpi_scale: float;
@@ -35,7 +34,6 @@ round_pow2 :: (v: float) -> s32 {
     return cast(s32) (vi + 1);
 }
 
-
 line :: (sx: float, sy: float, ex: float, ey: float) #c_call {
     sgl_begin_lines();
     sgl_c4b(255, 255, 0, 128);
@@ -45,11 +43,11 @@ line :: (sx: float, sy: float, ex: float, ey: float) #c_call {
 }
 
 init :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
 
     state.dpi_scale = sapp_dpi_scale();
     sg_setup(*(sg_desc.{
-        environment = xx sglue_environment(),
+        environment = xx,force sglue_environment(),
         logger = .{ func = slog_func },
     }));
     sgl_setup(*(sgl_desc_t.{
@@ -228,7 +226,7 @@ frame :: () #c_call {
                 clear_value = .{ 0.3, 0.3, 0.32, 1.0 },
             },
         },
-        swapchain = xx sglue_swapchain(),
+        swapchain = xx,force sglue_swapchain(),
     };
     sg_begin_pass(*pass);
     sgl_draw();

--- a/examples/offscreen/module.jai
+++ b/examples/offscreen/module.jai
@@ -15,7 +15,6 @@
 
 OFFSCREEN_SAMPLE_COUNT :: 1;
 
-default_context: Context;
 state: struct {
     offscreen: struct {
         pass_action: sg_pass_action;
@@ -36,10 +35,10 @@ state: struct {
 }
 
 init :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
 
     sg_setup(*(sg_desc.{
-        environment = xx sglue_environment(),
+        environment = xx,force sglue_environment(),
         logger = .{ func = slog_func },
     }));
 
@@ -93,8 +92,8 @@ init :: () #c_call {
     }));
     state.sphere = sshape_element_range(*buf);
 
-    vbuf := sg_make_buffer(xx *sshape_vertex_buffer_desc(*buf));
-    ibuf := sg_make_buffer(xx *sshape_index_buffer_desc(*buf));
+    vbuf := sg_make_buffer(xx,force *sshape_vertex_buffer_desc(*buf));
+    ibuf := sg_make_buffer(xx,force *sshape_index_buffer_desc(*buf));
 
     // pipeline-state-object for offscreen-rendered donut, don't need texture coord here
     offscreen_pip_desc := sg_pipeline_desc.{
@@ -109,9 +108,9 @@ init :: () #c_call {
         },
         colors[0] = .{ pixel_format = .RGBA8 },
     };
-    offscreen_pip_desc.layout.buffers[0] = xx sshape_vertex_buffer_layout_state();
-    offscreen_pip_desc.layout.attrs[ATTR_offscreen_position] = xx sshape_position_vertex_attr_state();
-    offscreen_pip_desc.layout.attrs[ATTR_offscreen_normal] = xx sshape_normal_vertex_attr_state();
+    offscreen_pip_desc.layout.buffers[0] = xx,force sshape_vertex_buffer_layout_state();
+    offscreen_pip_desc.layout.attrs[ATTR_offscreen_position] = xx,force sshape_position_vertex_attr_state();
+    offscreen_pip_desc.layout.attrs[ATTR_offscreen_normal] = xx,force sshape_normal_vertex_attr_state();
     state.offscreen.pip = sg_make_pipeline(*offscreen_pip_desc);
 
     // and another pipeline-state-object for the default pass
@@ -124,10 +123,10 @@ init :: () #c_call {
             write_enabled = true,
         },
     };
-    default_pip_desc.layout.buffers[0] = xx sshape_vertex_buffer_layout_state();
-    default_pip_desc.layout.attrs[ATTR_default_position] = xx sshape_position_vertex_attr_state();
-    default_pip_desc.layout.attrs[ATTR_default_normal] = xx sshape_normal_vertex_attr_state();
-    default_pip_desc.layout.attrs[ATTR_default_texcoord0] = xx sshape_texcoord_vertex_attr_state();
+    default_pip_desc.layout.buffers[0] = xx,force sshape_vertex_buffer_layout_state();
+    default_pip_desc.layout.attrs[ATTR_default_position] = xx,force sshape_position_vertex_attr_state();
+    default_pip_desc.layout.attrs[ATTR_default_normal] = xx,force sshape_normal_vertex_attr_state();
+    default_pip_desc.layout.attrs[ATTR_default_texcoord0] = xx,force sshape_texcoord_vertex_attr_state();
     state.default.pip = sg_make_pipeline(*default_pip_desc);
 
     // a sampler object for sampling the render target as texture
@@ -154,7 +153,7 @@ init :: () #c_call {
 }
 
 frame :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
 
     t := cast(float) (sapp_frame_duration() * 60.0);
     state.rx += 1.0 * t;
@@ -181,7 +180,7 @@ frame :: () #c_call {
             eye_dist = 2.0,
         ),
     };
-    sg_begin_pass(*(sg_pass.{ action = state.default.pass_action, swapchain = xx sglue_swapchain() }));
+    sg_begin_pass(*(sg_pass.{ action = state.default.pass_action, swapchain = xx,force sglue_swapchain() }));
     sg_apply_pipeline(state.default.pip);
     sg_apply_bindings(*state.default.bind);
     sg_apply_uniforms(UB_vs_params, *(sg_range.{ ptr = *vs_params, size = size_of(type_of(vs_params)) }));

--- a/examples/saudio/module.jai
+++ b/examples/saudio/module.jai
@@ -25,7 +25,7 @@ state: struct {
 
 init :: () #c_call {
     sg_setup(*(sg_desc.{
-        environment = xx sglue_environment(),
+        environment = xx,force sglue_environment(),
         logger = .{ func = slog_func },
     }));
     saudio_setup(*(saudio_desc.{
@@ -45,7 +45,7 @@ frame :: () #c_call {
         }
     }
 
-    sg_begin_pass(*(sg_pass.{ action = state.pass_action, swapchain = xx sglue_swapchain() }));
+    sg_begin_pass(*(sg_pass.{ action = state.pass_action, swapchain = xx,force sglue_swapchain() }));
     sg_end_pass();
     sg_commit();
 }

--- a/examples/sgl-context-sapp/module.jai
+++ b/examples/sgl-context-sapp/module.jai
@@ -20,7 +20,6 @@ OFFSCREEN_SAMPLECOUNT :: 1;
 OFFSCREEN_WIDTH :: 32;
 OFFSCREEN_HEIGHT :: 32;
 
-default_context: Context;
 state: struct {
     angle_deg: float64;
     offscreen: struct {
@@ -37,10 +36,10 @@ state: struct {
 }
 
 init :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
 
     sg_setup(*(sg_desc.{
-        environment = xx sglue_environment(),
+        environment = xx,force sglue_environment(),
         logger.func = slog_func,
     }));
 
@@ -104,7 +103,7 @@ init :: () #c_call {
 }
 
 frame :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
 
     state.angle_deg += sapp_frame_duration() * 60.0;
     a := sgl_rad(cast(float) state.angle_deg);
@@ -120,7 +119,7 @@ frame :: () #c_call {
     sgl_set_context(SGL_DEFAULT_CONTEXT);
     sgl_defaults();
     sgl_enable_texture();
-    sgl_texture(xx state.offscreen.img, xx state.display.smp);
+    sgl_texture(xx,force state.offscreen.img, xx,force state.display.smp);
     sgl_load_pipeline(state.display.sgl_pip);
     sgl_matrix_mode_projection();
     sgl_perspective(sgl_rad(45.0), sapp_widthf()/sapp_heightf(), 0.1, 100.0);
@@ -133,7 +132,7 @@ frame :: () #c_call {
     sg_begin_pass(*(sg_pass.{ action = state.offscreen.pass_action, attachments = state.offscreen.attachments }));
         sgl_context_draw(state.offscreen.sgl_ctx);
     sg_end_pass();
-    sg_begin_pass(*(sg_pass.{ action = state.display.pass_action, swapchain = xx sglue_swapchain() }));
+    sg_begin_pass(*(sg_pass.{ action = state.display.pass_action, swapchain = xx,force sglue_swapchain() }));
         sgl_context_draw(SGL_DEFAULT_CONTEXT);
     sg_end_pass();
     sg_commit();

--- a/examples/triangle/module.jai
+++ b/examples/triangle/module.jai
@@ -10,7 +10,6 @@
 #import,dir "../../sokol/glue"(USE_GL=USE_GL);
 #load "./shader.jai";
 
-default_context: Context;
 state: struct {
     pip:         sg_pipeline;
     bind:        sg_bindings;
@@ -18,10 +17,10 @@ state: struct {
 }
 
 init :: () #c_call {
-    push_context,defer_pop default_context;
+    push_context,defer_pop;
 
     sg_setup(*(sg_desc.{
-        environment = xx sglue_environment(),
+        environment = xx,force sglue_environment(),
         logger = .{ func = slog_func },
     }));
 
@@ -50,7 +49,7 @@ init :: () #c_call {
 }
 
 frame :: () #c_call {
-    sg_begin_pass(*(sg_pass.{ action = state.pass_action, swapchain = xx sglue_swapchain() }));
+    sg_begin_pass(*(sg_pass.{ action = state.pass_action, swapchain = xx,force sglue_swapchain() }));
     sg_apply_pipeline(state.pip);
     sg_apply_bindings(*state.bind);
     sg_draw(0, 3, 1);


### PR DESCRIPTION
- Removed `default_context: Context` in function since we can use `push_context` with no params to get a default context, very handy.
- Updated some cast (mostly sglue_environment and sglue_swapchain) now that `xx` cannot cast from a struct to another without `,force`, which is fair enough. I'm not exactly sure if we can avoid doing this when using types from different modules, i'll need to investigate later.

Should: fix #2 and fix #3.